### PR TITLE
Update GitPython to <3.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.6.0
+- Update GitPython dependency version to <3.0 (PR #9)
+
 ## 0.5.1
 - Fix typo in action name
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.1
+- Fix typo in action name
+
 ## 0.5.0
 
 - Added 4 new actions

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description : Git SCM
 keywords:
   - git
   - scm
-version : 0.5.1
+version : 0.6.0
 author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-gitpython==1.0.1
+gitpython<3.0.0


### PR DESCRIPTION
Partial fix for [CI failures](https://circleci.com/gh/StackStorm-Exchange/stackstorm-git/123). Fixes issue that causes:

> TypeError: PackingType of packed-Refs not understood: '# pack-refs with: peeled fully-peeled sorted'

I did not update to GitPython v3.0.0+ because that drops support for Python < 3. I logged this as in issue #8.