### PR TITLE
Update gitpython 3.0.0 to 3.1.40

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -15,4 +15,4 @@ jobs:
       enable-common-libs: true
       #apt-cache-version: v0
       #py-cache-version: v0
-      python-version: "3.8
+      python-version: "3.8"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -15,3 +15,4 @@ jobs:
       enable-common-libs: true
       #apt-cache-version: v0
       #py-cache-version: v0
+      python-version: "3.8

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
       enable-common-libs: true
       #apt-cache-version: v0
       #py-cache-version: v0
+      python-version: "3.8"
 
   tag_release:
     needs: build_and_test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.1.0
+
+* Update GitPython to 3.1.40.
+* Change Python version for CI Test from 3.6 to 3.8.
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## 1.1.0
 
-* Update GitPython to 3.1.40.
+* Update GitPython to 3.1.40 (security).
 * Change Python version for CI Test from 3.6 to 3.8.
 
 ## 1.0.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
 * Update GitPython to 3.1.40 (security).
 * Change Python version for CI Test from 3.6 to 3.8.
+* Drop Python 3.6 support.
 
 ## 1.0.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.1.0
+## 2.0.0
 
 * Update GitPython to 3.1.40 (security).
 * Change Python version for CI Test from 3.6 to 3.8.

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description : Git SCM
 keywords:
   - git
   - scm
-version: 1.1.0
+version: 2.0.0
 author: StackStorm, Inc.
 email: info@stackstorm.com
 python_versions:

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ description : Git SCM
 keywords:
   - git
   - scm
-version: 1.0.0
+version: 1.1.0
 author: StackStorm, Inc.
 email: info@stackstorm.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-gitpython<3.0.0
+gitpython==3.1.40


### PR DESCRIPTION
Update gitpython 3.0.0 to 3.1.40

Close some Snyk Sec fingings:
https://security.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-5840584
https://app.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-3113858
https://app.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-5871282
https://app.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-5876644
https://app.snyk.io/vuln/SNYK-PYTHON-GITPYTHON-2407255

Change CI Python Version from 3.6 to 3.8 because the actual gitpython version works only with >= 3.7.

Drop Python 3.6 support.